### PR TITLE
Upload to allennlp channel on anaconda cloud

### DIFF
--- a/.circleci/build_steps.sh
+++ b/.circleci/build_steps.sh
@@ -29,6 +29,6 @@ conda install --yes --quiet conda-forge-ci-setup=1 conda-build
 source run_conda_forge_build_setup
 
 conda build /home/conda/recipe_root -m /home/conda/feedstock_root/.ci_support/${CONFIG}.yaml --quiet
-upload_or_check_non_existence /home/conda/recipe_root conda-forge --channel=main -m /home/conda/feedstock_root/.ci_support/${CONFIG}.yaml
+upload_or_check_non_existence /home/conda/recipe_root allennlp --channel=main -m /home/conda/feedstock_root/.ci_support/${CONFIG}.yaml
 
 touch "/home/conda/feedstock_root/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,4 +57,4 @@ install:
 script:
   - conda build ./recipe -m ./.ci_support/${CONFIG}.yaml
 
-  - upload_or_check_non_existence ./recipe conda-forge --channel=main -m ./.ci_support/${CONFIG}.yaml
+  - upload_or_check_non_existence ./recipe allennlp --channel=main -m ./.ci_support/${CONFIG}.yaml

--- a/README.md
+++ b/README.md
@@ -23,18 +23,18 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-allennlp-green.svg)](https://anaconda.org/conda-forge/allennlp) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/allennlp.svg)](https://anaconda.org/conda-forge/allennlp) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/allennlp.svg)](https://anaconda.org/conda-forge/allennlp) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/allennlp.svg)](https://anaconda.org/conda-forge/allennlp) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-allennlp-green.svg)](https://anaconda.org/allennlp/allennlp) | [![Conda Downloads](https://img.shields.io/conda/dn/allennlp/allennlp.svg)](https://anaconda.org/allennlp/allennlp) | [![Conda Version](https://img.shields.io/conda/vn/allennlp/allennlp.svg)](https://anaconda.org/allennlp/allennlp) | [![Conda Platforms](https://img.shields.io/conda/pn/allennlp/allennlp.svg)](https://anaconda.org/allennlp/allennlp) |
 
 Installing allennlp
 ===================
 
-Installing `allennlp` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `allennlp` from the `allennlp` channel can be achieved by adding `allennlp` to your channels with:
 
 ```
-conda config --add channels conda-forge
+conda config --add channels allennlp
 ```
 
-Once the `conda-forge` channel has been enabled, `allennlp` can be installed with:
+Once the `allennlp` channel has been enabled, `allennlp` can be installed with:
 
 ```
 conda install allennlp
@@ -43,44 +43,10 @@ conda install allennlp
 It is possible to list all of the versions of `allennlp` available on your platform with:
 
 ```
-conda search allennlp --channel conda-forge
+conda search allennlp --channel allennlp
 ```
 
 
-About conda-forge
-=================
-
-conda-forge is a community-led conda channel of installable packages.
-In order to provide high-quality builds, the process has been automated into the
-conda-forge GitHub organization. The conda-forge organization contains one repository
-for each of the installable packages. Such a repository is known as a *feedstock*.
-
-A feedstock is made up of a conda recipe (the instructions on what and how to build
-the package) and the necessary configurations for automatic building using freely
-available continuous integration services. Thanks to the awesome service provided by
-[CircleCI](https://circleci.com/), [AppVeyor](http://www.appveyor.com/)
-and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
-packages to the [conda-forge](https://anaconda.org/conda-forge)
-[Anaconda-Cloud](http://docs.anaconda.org/) channel for Linux, Windows and OSX respectively.
-
-To manage the continuous integration and simplify feedstock maintenance
-[conda-smithy](http://github.com/conda-forge/conda-smithy) has been developed.
-Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
-this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
-
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
-
-Terminology
-===========
-
-**feedstock** - the conda recipe (raw material), supporting scripts and CI configuration.
-
-**conda-smithy** - the tool which helps orchestrate the feedstock.
-                   Its primary use is in the construction of the CI ``.yml`` files
-                   and simplify the management of *many* feedstocks.
-
-**conda-forge** - the place where the feedstock and smithy live and work to
-                  produce the finished article (built conda distributions)
 
 
 Updating allennlp-feedstock
@@ -91,8 +57,8 @@ package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
-`conda-forge` channel, whereupon the built conda packages will be available for
-everybody to install and use from the `conda-forge` channel.
+`allennlp` channel, whereupon the built conda packages will be available for
+everybody to install and use from the `allennlp` channel.
 Note that all branches in the conda-forge/allennlp-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,4 +1,6 @@
 channels:
+  targets:
+    - [allennlp, main]
   sources:
   - pytorch
   - conda-forge


### PR DESCRIPTION
This PR configures the feedstock to actually upload the (successfully) built binaries to anaconda cloud